### PR TITLE
Change logic to fix an interval transformation bug

### DIFF
--- a/legzo.m
+++ b/legzo.m
@@ -40,6 +40,6 @@ for ii=1:m
     w(n+1-ii) = w(ii);
 end
 
-if a ~= -1 && b ~= 1
+if a ~= -1 || b ~= 1
     x = (x+1)*(h/2) + a;
 end


### PR DESCRIPTION
Super simple change, the logic should transform the interval when *either* endpoint is abnormal, not only when *both* are abnormal.

This pull request fixes an issue where intervals were not always transformed appropriately from (-1,1) to (a,b)

Previously: Currently `legzo(3, 0, 1)` would incorrectly return the same results as `legzo(3)`
This is no longer the case.

(Doesn't currently come with tests for the bug, just a quick fix I saw while using this code for another project I'm working on)
